### PR TITLE
Feature!(#64): version flag removal

### DIFF
--- a/R/calculate-consumed-biomass.R
+++ b/R/calculate-consumed-biomass.R
@@ -54,7 +54,7 @@
 #'                select_groups = groups_rest, select_variable = "Grazing",
 #'                prm_run = prm_run, bboxes = bboxes)
 #' df_dm <- load_dietcheck(dietcheck = file.path(d, "outputSETASDietCheck.txt"),
-#'                         fgs = fgs, prm_run = prm_run, version_flag = 2, convert_names = TRUE)
+#'                         fgs = fgs, prm_run = prm_run, convert_names = TRUE)
 #' vol <- load_nc_physics(nc = nc_gen, select_physics = "volume",
 #'                        prm_run = prm_run, bboxes = bboxes, aggregate_layers = FALSE)
 #'

--- a/R/change-prm.R
+++ b/R/change-prm.R
@@ -32,8 +32,7 @@ change_prm <- function(
   roc,
   parameter,
   relative = TRUE,
-  save_to_disc = TRUE,
-  version_flag = 2
+  save_to_disc = TRUE
 ) {
   if (length(parameter) != 1) {
     stop("Please suply only one parameter per function call.")
@@ -64,15 +63,10 @@ change_prm <- function(
       new_value <- roc
     }
 
-    # Update value. Some pesky expectations have to be added here.
-    if (
-      is.element(parameter, c("mum", "C", "mQ", "mL", "jmL", "jmQ")) &
-        version_flag == 1
-    ) {
-      prm_biol[pos] <- paste(paste0(flag, "_T15"), new_value, sep = "\t")
-    } else {
-      prm_biol[pos] <- paste(flag, new_value, sep = "\t")
-    }
+    # Update value.
+
+    prm_biol[pos] <- paste(flag, new_value, sep = "\t")
+
     return(prm_biol)
   }
 

--- a/R/load-dietcheck.R
+++ b/R/load-dietcheck.R
@@ -23,14 +23,12 @@
 #' diet <- load_dietcheck(dietcheck, fgs, prm_run)
 #' head(diet, n = 10)
 
-#BJS 7/6/16 change to be compatible with trunk version; added version_flag
 load_dietcheck <- function(
   dietcheck,
   fgs,
   prm_run,
   convert_names = FALSE,
-  report = FALSE,
-  version_flag = 2
+  report = FALSE
 ) {
   # read in diet information
   diet <- utils::read.table(
@@ -41,20 +39,19 @@ load_dietcheck <- function(
   )
 
   #Check if multiple stocks are available per functional group for trunk branch!
-  if (version_flag == 2) {
-    if (all(diet$Stock) == 0) {
-      diet$Stock <- NULL
-    } else {
-      stop(
-        "Multiple stocks present. Dietcheck only works with 1 stock per funtional group."
-      )
-    }
 
-    diet$Cohort <- diet$Cohort + 1 # Cohorts start with 0 in DietCheck.txt!
+  if (all(diet$Stock) == 0) {
+    diet$Stock <- NULL
+  } else {
+    stop(
+      "Multiple stocks present. Dietcheck only works with 1 stock per funtional group."
+    )
   }
 
+  diet$Cohort <- diet$Cohort + 1 # Cohorts start with 0 in DietCheck.txt!
+
   # Column Updated was added to trunk code.
-  if (version_flag == 2 & "Updated" %in% names(diet)) {
+  if ("Updated" %in% names(diet)) {
     prey_col_start <- 5 #bjs remove magic number below
   } else {
     prey_col_start <- 4 #bjs remove magic number below
@@ -112,12 +109,10 @@ load_dietcheck <- function(
 
   names(diet_long)[names(diet_long) == "Predator"] <- "pred" #bjs predator -> colnames(diet)[2]
 
-  if (version_flag == 2) {
-    names(diet_long)[names(diet_long) == "Cohort"] <- "agecl" #bjs cohort -> colnames(diet)[3]
-    # Column Updated was added to trunk code.
-    if ("Updated" %in% names(diet_long)) {
-      diet_long <- diet_long[, names(diet_long) != "Updated"]
-    }
+  names(diet_long)[names(diet_long) == "Cohort"] <- "agecl" #bjs cohort -> colnames(diet)[3]
+  # Column Updated was added to trunk code.
+  if ("Updated" %in% names(diet_long)) {
+    diet_long <- diet_long[, names(diet_long) != "Updated"]
   }
 
   names(diet_long) <- tolower(names(diet_long))

--- a/R/load-dietmatrix.R
+++ b/R/load-dietmatrix.R
@@ -11,7 +11,6 @@
 #' diet matrix entries.
 #' @param convert_names Logical indicating if group codes are transformed to LongNames (\code{TRUE})
 #' or not (default = \code{FALSE}).
-#' @param version_flag The version of ATLANTIS model. 1 for bec_dev, 2 for trunk. \code{default is 2.}.
 #' @return dataframe of the availability matrix in long format with columns
 #' pred, pred_stanza (1 = juvenile, 2 = adult), prey_stanza, prey, avail, code.
 #' @param dietmatrix Dataframe of the ATLANTIS dietmatrix generated with \code{load_dietmatrix}
@@ -41,8 +40,7 @@ load_dietmatrix <- function(
   prm_biol,
   fgs,
   transform = TRUE,
-  convert_names = FALSE,
-  version_flag = 2
+  convert_names = FALSE
 ) {
   fgs_data <- load_fgs(fgs = fgs)
   acr <- fgs_data$Code[
@@ -63,10 +61,8 @@ load_dietmatrix <- function(
   coh2 <- acr[agecl == 2]
   coh1 <- acr[agecl == 1]
 
-  if (version_flag == 2) {
-    coh10 <- c(coh10, coh2)
-    coh2 <- NULL
-  }
+  coh10 <- c(coh10, coh2)
+  coh2 <- NULL
 
   if (length(c(coh10, coh2, coh1)) != length(acr)) {
     stop("Incomplete functional groups file.")
@@ -237,12 +233,3 @@ write_diet <- function(dietmatrix, prm_biol, save_to_disc = TRUE) {
     }
   }
 }
-
-# sicily debugging
-# dir <- "z:/my_data_alex/Matteo/"
-# prm_biol <- list.files(dir)[2]
-# fgs <- list.files(dir)[1]
-# transform <- FALSE
-# convert_names <- FALSE
-# version_flag <- 1
-# dietmatrix <- load_dietmatrix(dir, prm_biol, fgs, transform, convert_names, version_flag)

--- a/R/load-mort.R
+++ b/R/load-mort.R
@@ -28,7 +28,6 @@
 #' df <- load_mort(mortFile, prm_run, fgs)
 #' head(df)
 
-#BJS 7/15/16 add version_flag and make compatible with trunk output
 load_mort <- function(mortFile, prm_run, fgs, convert_names = F) {
   mort <- load_txt(file = mortFile, id_col = c("Time"))
 

--- a/R/load-spec-mort.R
+++ b/R/load-spec-mort.R
@@ -27,7 +27,6 @@
 #' df <- load_spec_mort(specmort, prm_run, fgs)
 #' head(df)
 
-#BJS 7/15/16 add version_flag and make compatible with trunk output
 load_spec_mort <- function(
   mortFile,
   prm_run,

--- a/R/load-spec-pred-mort.R
+++ b/R/load-spec-pred-mort.R
@@ -20,45 +20,24 @@
 #' df <- load_spec_pred_mort(specmort, prm_run, fgs)
 #' head(df)
 
-#BJS 7/15/16 add version_flag and make compatible with trunk output
 load_spec_pred_mort <- function(
   specmort,
   prm_run,
   fgs,
-  convert_names = FALSE,
-  version_flag = 2
+  convert_names = FALSE
 ) {
-  if (version_flag == 1) {
-    mort <- load_txt(file = specmort)
-    mort <- mort |>
-      tidyr::separate(
-        col = "code",
-        into = c("prey", "agecl", "stock", "pred", "mort"),
-        convert = TRUE
-      )
-    # check uniqueness of column notsure and mort
-    if (
-      any(
-        sapply(mort[, c("stock", "mort")], function(x) length(unique(x))) != 1
-      )
-    ) {
-      stop(
-        "Multiple stocks present. This is not covered by the current version of atlantistools. Please contact the package development team."
-      )
-    }
-  } else if (version_flag == 2) {
-    mort <- load_txt(
-      file = specmort,
-      id_col = c("Time", "Group", "Cohort", "Stock")
+  mort <- load_txt(
+    file = specmort,
+    id_col = c("Time", "Group", "Cohort", "Stock")
+  )
+  mort <- mort |>
+    dplyr::rename(pred = group, agecl = cohort, prey = code)
+  if (any(sapply(mort[, "stock"], function(x) length(unique(x))) != 1)) {
+    stop(
+      "Multiple stocks present. This is not covered by the current version of atlantistools. Please contact the package development team."
     )
-    mort <- mort |>
-      dplyr::rename(pred = group, agecl = cohort, prey = code)
-    if (any(sapply(mort[, "stock"], function(x) length(unique(x))) != 1)) {
-      stop(
-        "Multiple stocks present. This is not covered by the current version of atlantistools. Please contact the package development team."
-      )
-    }
   }
+
   mort$agecl <- mort$agecl + 1
 
   # Remove unnecessary columns

--- a/R/sc-init.R
+++ b/R/sc-init.R
@@ -78,8 +78,7 @@ sc_init <- function(
   fgs,
   bboxes,
   pred = NULL,
-  set_avail = NULL,
-  version_flag = 2
+  set_avail = NULL
 ) {
   fgs_data <- load_fgs(fgs = fgs)
 
@@ -259,8 +258,7 @@ sc_init <- function(
   dm <- load_dietmatrix(
     prm_biol = prm_biol,
     fgs = fgs,
-    convert_names = TRUE,
-    version_flag = version_flag
+    convert_names = TRUE
   ) |>
     dplyr::filter(avail != 0) |>
     dplyr::left_join(ass_type, by = "prey")

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,37 +64,3 @@ release_questions <- function() {
     "Have you run devtools::build_win(args = '--compact-vignettes=both') to check with win-builder?"
   )
 }
-
-# dir <- "C:/Users/alexanderke/Dropbox/Atlantis_SoS_Files_Alex"
-# setwd(dir)
-# nomeNc <- "output/out_newfleet9"
-#
-# nc_gen <- paste(nomeNc,".nc",sep="")
-# nc_prod <- paste(nomeNc,"PROD.nc",sep="")
-# dietcheck <- paste(nomeNc,"DietCheck.txt",sep="")
-# yoy <- paste(nomeNc,"YOY.txt",sep="")
-# ssb <- paste(nomeNc,"SSB.txt",sep="")
-# specmort <- paste(nomeNc,"SpecificMort.txt",sep="")
-# predspecmort <-paste(nomeNc,"SpecificPredMort.txt",sep="")
-# version_flag <- 1
-#
-# prm_run <- "Sic_run_fishing_F_gape100_65yr.prm"
-# prm_biol <- "Sic_biol_newfleet21.prm"
-# fgs <- "newFGHorMigr.csv"
-# bgm <- "geometry.bgm"
-# init <- "inSic26042017.nc"
-#
-# bboxes <- get_boundary(boxinfo = load_box(bgm))
-# bps <- load_bps(fgs, init)
-# bio_conv <- get_conv_mgnbiot(prm_biol)
-#
-# groups <- get_groups(fgs)
-# groups_age <- get_age_groups(fgs)
-#
-# load_nc(nc = nc_gen, bps = bps, select_groups = groups_age[1:5], select_variable = "ResN", fgs = fgs, prm_run = prm_run, bboxes = bboxes)
-#
-# nc = nc_gen
-# select_groups = groups_age[1:5]
-# select_variable = "ResN"
-#
-# agemat <- prm_to_df(prm_biol,  fgs, group = get_age_acronyms(fgs), "age_mat")

--- a/data-raw/data-create-reference-dfs.R
+++ b/data-raw/data-create-reference-dfs.R
@@ -90,7 +90,6 @@ ref_dm <- atlantistools::load_dietcheck(
   dietcheck = dietcheck,
   fgs = fgs,
   prm_run = prm_run,
-  version_flag = 2,
   convert_names = TRUE
 )
 

--- a/man/calculate_consumed_biomass.Rd
+++ b/man/calculate_consumed_biomass.Rd
@@ -68,7 +68,7 @@ df_grz <- load_nc(nc = nc_prod, bps = bps, fgs = fgs,
                select_groups = groups_rest, select_variable = "Grazing",
                prm_run = prm_run, bboxes = bboxes)
 df_dm <- load_dietcheck(dietcheck = file.path(d, "outputSETASDietCheck.txt"),
-                        fgs = fgs, prm_run = prm_run, version_flag = 2, convert_names = TRUE)
+                        fgs = fgs, prm_run = prm_run, convert_names = TRUE)
 vol <- load_nc_physics(nc = nc_gen, select_physics = "volume",
                        prm_run = prm_run, bboxes = bboxes, aggregate_layers = FALSE)
 

--- a/man/change_prm.Rd
+++ b/man/change_prm.Rd
@@ -10,8 +10,7 @@ change_prm(
   roc,
   parameter,
   relative = TRUE,
-  save_to_disc = TRUE,
-  version_flag = 2
+  save_to_disc = TRUE
 )
 }
 \arguments{
@@ -34,8 +33,6 @@ be passed directly. Default is \code{TRUE}.}
 
 \item{save_to_disc}{Logical indicating if the resulting prm file should be overwritten
 (\code{TRUE}) or not (\code{FALSE}). Defaults to \code{TRUE}.}
-
-\item{version_flag}{The version of ATLANTIS model. 1 for bec_dev, 2 for trunk. \code{default is 2.}.}
 }
 \value{
 parameterfile *.prm file with the new parameter values.

--- a/man/load_dietcheck.Rd
+++ b/man/load_dietcheck.Rd
@@ -4,14 +4,7 @@
 \alias{load_dietcheck}
 \title{Read in the atlantis dietcheck.txt file and perform some basic data transformations.}
 \usage{
-load_dietcheck(
-  dietcheck,
-  fgs,
-  prm_run,
-  convert_names = FALSE,
-  report = FALSE,
-  version_flag = 2
-)
+load_dietcheck(dietcheck, fgs, prm_run, convert_names = FALSE, report = FALSE)
 }
 \arguments{
 \item{dietcheck}{Character string giving the connection of the dietcheck file.
@@ -28,8 +21,6 @@ or not (default = \code{FALSE}).}
 
 \item{report}{Logical indicating if incomplete DietCheck information shall
 be printed \code{TRUE} or not \code{FALSE}.}
-
-\item{version_flag}{The version of ATLANTIS model. 1 for bec_dev, 2 for trunk. \code{default is 2.}.}
 }
 \value{
 A \code{data.frame} in long format with the following column names:

--- a/man/load_dietmatrix.Rd
+++ b/man/load_dietmatrix.Rd
@@ -5,13 +5,7 @@
 \alias{write_diet}
 \title{Extract the dietmatrix from the biological parameterfile}
 \usage{
-load_dietmatrix(
-  prm_biol,
-  fgs,
-  transform = TRUE,
-  convert_names = FALSE,
-  version_flag = 2
-)
+load_dietmatrix(prm_biol, fgs, transform = TRUE, convert_names = FALSE)
 
 write_diet(dietmatrix, prm_biol, save_to_disc = TRUE)
 }
@@ -29,8 +23,6 @@ diet matrix entries.}
 
 \item{convert_names}{Logical indicating if group codes are transformed to LongNames (\code{TRUE})
 or not (default = \code{FALSE}).}
-
-\item{version_flag}{The version of ATLANTIS model. 1 for bec_dev, 2 for trunk. \code{default is 2.}.}
 
 \item{dietmatrix}{Dataframe of the ATLANTIS dietmatrix generated with \code{load_dietmatrix}
 using \code{transform = FALSE}.}

--- a/man/load_spec_pred_mort.Rd
+++ b/man/load_spec_pred_mort.Rd
@@ -4,13 +4,7 @@
 \alias{load_spec_pred_mort}
 \title{Load mortality information from outputSpecificPredMort.txt}
 \usage{
-load_spec_pred_mort(
-  specmort,
-  prm_run,
-  fgs,
-  convert_names = FALSE,
-  version_flag = 2
-)
+load_spec_pred_mort(specmort, prm_run, fgs, convert_names = FALSE)
 }
 \arguments{
 \item{specmort}{Character string giving the connection of the specific mortality file.
@@ -24,8 +18,6 @@ The filename usually contains \code{Groups} and does end in \code{.csv}.}
 
 \item{convert_names}{Logical indicating if group codes are transformed to LongNames (\code{TRUE})
 or not (default = \code{FALSE}).}
-
-\item{version_flag}{The version of ATLANTIS model. 1 for bec_dev, 2 for trunk. \code{default is 2.}.}
 }
 \value{
 Dataframe with information about ssb in tonnes and recruits in

--- a/man/sc_init.Rd
+++ b/man/sc_init.Rd
@@ -5,15 +5,7 @@
 \alias{plot_sc_init}
 \title{Sanity check initial conditions file}
 \usage{
-sc_init(
-  init,
-  prm_biol,
-  fgs,
-  bboxes,
-  pred = NULL,
-  set_avail = NULL,
-  version_flag = 2
-)
+sc_init(init, prm_biol, fgs, bboxes, pred = NULL, set_avail = NULL)
 
 plot_sc_init(df, mult_mum, mult_c, pred = NULL)
 }
@@ -35,8 +27,6 @@ predators are selected.}
 
 \item{set_avail}{Numeric value. All present availabilities can be set to a specific value.
 Default value is \code{NULL} which results in no changes to the present availability matrix.}
-
-\item{version_flag}{The version of ATLANTIS model. 1 for bec_dev, 2 for trunk. \code{default is 2.}.}
 
 \item{df}{Dataframe to pass to \code{plot_sc_init()}. df should be generated with
 sc_init or read in from *.rda (also generated with sc_init()).}

--- a/tests/testthat/test-load-dietcheck.R
+++ b/tests/testthat/test-load-dietcheck.R
@@ -14,8 +14,7 @@ test_that("test output numbers trunk", {
     dietcheck = file.path(d, "outputSETASDietCheck.txt"),
     fgs = file.path(d, "SETasGroupsDem_NoCep.csv"),
     prm_run = file.path(d, "VMPA_setas_run_fishing_F_Trunk.prm"),
-    report = FALSE,
-    version_flag = 2
+    report = FALSE
   )
 
   # expect_true(all(abs(test1$check - 1) < 0.001))

--- a/vignettes/package-demo.Rmd
+++ b/vignettes/package-demo.Rmd
@@ -179,7 +179,7 @@ df_grz <- load_nc(nc = nc_prod, bps = bps, fgs = fgs,
                select_groups = groups_rest, select_variable = "Grazing",
                prm_run = prm_run, bboxes = bboxes)
 df_dm <- load_dietcheck(dietcheck = file.path(d, "outputSETASDietCheck.txt"),
-                        fgs = fgs, prm_run = prm_run, version_flag = 2, convert_names = TRUE)
+                        fgs = fgs, prm_run = prm_run, convert_names = TRUE)
 vol <- load_nc_physics(nc = nc_gen, select_physics = "volume",
                        prm_run = prm_run, bboxes = bboxes, aggregate_layers = F)
 


### PR DESCRIPTION
Your commits explain the `who`, `what`, `where` and `when` of these changes. Your code shows the `how`. You do not need to reiterate this. This PR should complete the big picture by telling the `why`.

### Justification

The code was referencing different versions of the model; the trunk and a 10 year old development model. This was done by using an argument called `vesrion_flag` in many functions. Since there is only one version now, this is no longer needed. It was removed for all code, docs, rmds, and unit tests

fixes #64 

### Types of changes

What types of changes does your code introduce? Put an `x` in the boxes that apply. This will inform version updates

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other change (if none of the other choices apply) 

### Reviewer instructions

Run `devtools::check()` and `pkgdown::build_site()`. Make sure both run without errors

### Formatting

This repo contains an `air.toml` file that automatically formats code to a set of standards.
It is preferred that contributors and reviewers install the [air](https://posit-dev.github.io/air/) formatting tool.
